### PR TITLE
Simplificación de override de la configuración para veriricación de CSV

### DIFF
--- a/test/csvutil.js
+++ b/test/csvutil.js
@@ -2,20 +2,10 @@
 const path = require('path');
 
 const csvdata = require('csvdata');
-const merge = require('merge-anything');
 
 const { expect } = require('@hapi/code');
 const { DateTime } = require('luxon');
 
-const CSV_CHECK_OPTIONS = {
-	delimiter: ',',
-	duplicates: false,
-	emptyLines: true,
-	emptyValues: false,
-	encoding: 'utf8',
-	limit: false,
-	log: true
-};
 const DATE_FORMAT = 'M/d/yyyy';
 
 class CsvUtil
@@ -80,10 +70,10 @@ class CsvUtil
 
 module.exports = (lab, files, run, optionsOverride = {}) =>
 {
-	for (const filename of files)
+	for (const filename in files)
 	{
-		const config = merge.merge(CSV_CHECK_OPTIONS, optionsOverride);
-		const csv = new CsvUtil(lab, filename, config);
+		const checkConfig = files[filename];
+		const csv = new CsvUtil(lab, filename, checkConfig);
 		lab.experiment(filename, () => {
 			csv.check();
 			run(csv);

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1002,11 +1002,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "is-what": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.10.0.tgz",
-      "integrity": "sha512-U4RYCXNOmATQHlOPlOCHCfXyKEFIPqvyaKDqYRuLbD6EYKcTTfc3YXkAYjzOVxO3zt34L+Wh2feIyWrYiZ7kng=="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1069,15 +1064,6 @@
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.24.1.tgz",
       "integrity": "sha512-CgnIMKAWT0ghcuWFfCWBnWGOddM0zu6c4wZAWmD0NN7MZTnro0+833DF6tJep+xlxRPg4KtsYEHYLfTMBQKwYg=="
-    },
-    "merge-anything": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-3.0.4.tgz",
-      "integrity": "sha512-P/KCKyWsaIb0qRUWCYGgeyx3kqntZokkvRxvkkLIhCDCgD9KAaStavBipro4h4vHvlgCz5mXOmZhBDtQO3gMYw==",
-      "requires": {
-        "is-what": "^3.10.0",
-        "ts-toolbelt": "^6.12.1"
-      }
     },
     "merge2": {
       "version": "1.4.1",
@@ -1488,11 +1474,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "ts-toolbelt": {
-      "version": "6.13.6",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.13.6.tgz",
-      "integrity": "sha512-qqIexrhqCNOuSRCrJMOKor8UJxA4DYMB6fNpBmRAKJgmLXNj8TAiuCrs7Nm08fva+MEdQhEXmsnjBQarNSIWZg=="
     },
     "tslib": {
       "version": "1.13.0",

--- a/test/package.json
+++ b/test/package.json
@@ -12,7 +12,6 @@
     "@hapi/code": "^8.0.1",
     "@hapi/lab": "^22.0.4",
     "csvdata": "^1.7.0",
-    "luxon": "^1.24.1",
-    "merge-anything": "^3.0.4"
+    "luxon": "^1.24.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -8,23 +8,29 @@ const lab = exports.lab = Lab.script();
 
 const csvutil = require('./csvutil');
 
-const FILES = [
-	'confirmados.csv',
-	'confirmados_comunas.csv',
-	'confirmados_comunas_interpolado.csv',
-	'encuesta_sochimi.csv',
-	'muertes.csv',
-	'notificaciones.csv',
-	'pacientes_en_uci.csv',
-	'pcrs_region.csv',
-	'resumen_nacional.csv'
-];
+const CSV_CHECK_DEFAULT_CONFIG = {
+	delimiter: ',',
+	duplicates: false,
+	emptyLines: true,
+	emptyValues: false,
+	encoding: 'utf8',
+	limit: false,
+	log: true
+};
+const FILES = {
+	'confirmados.csv': CSV_CHECK_DEFAULT_CONFIG,
+	'confirmados_comunas.csv': CSV_CHECK_DEFAULT_CONFIG,
+	'confirmados_comunas_interpolado.csv': CSV_CHECK_DEFAULT_CONFIG,
+	'encuesta_sochimi.csv': CSV_CHECK_DEFAULT_CONFIG,
+	'muertes.csv': CSV_CHECK_DEFAULT_CONFIG,
+	'notificaciones.csv': { ...CSV_CHECK_DEFAULT_CONFIG, emptyValues: true },
+	'pacientes_en_uci.csv': CSV_CHECK_DEFAULT_CONFIG,
+	'pcrs_region.csv': CSV_CHECK_DEFAULT_CONFIG,
+	'resumen_nacional.csv': CSV_CHECK_DEFAULT_CONFIG,
+};
 
 // Check dates
 csvutil(lab, FILES, csv => {
 	csv.testDate('date year at least 2020', (date, rawDate) => expect(date.year, rawDate).to.to.be.at.least(2020));
 	csv.testDate('date at most today', (date, rawDate) => expect(+date, rawDate).to.to.be.at.most(+DateTime.utc()));
 });
-
-// Check specific files that must have values
-csvutil(lab, ['notificaciones.csv'], () => {}, { emptyValues: true });


### PR DESCRIPTION
Debido a que es probable que distintos archivos CSV tengan que ser verificados con opciones distintas, cambié la llamada para que ```test.js``` especifique siempre la configuración. Esto evita tener que hacer llamadas adicionales por cada nueva configuración.